### PR TITLE
Check for client before closing

### DIFF
--- a/Classes/Client/HttpClient.php
+++ b/Classes/Client/HttpClient.php
@@ -626,7 +626,7 @@ class HttpClient {
    * @return void
    */
   public function __destruct() {
-    if ($this -> client !== false) {
+    if ($this -> client) {
       curl_close($this -> client);
     }
   }


### PR DESCRIPTION
`$this->client` may not only be false but otherwise falsey, which keeps logging errors when attempting to `curl_close` it.

BTW, there aren't any unit tests to adjust are there? `^^`